### PR TITLE
fixed cart modal, updated cart icon in header

### DIFF
--- a/src/components/Cart/CartModal/StyledCartModal.styled.js
+++ b/src/components/Cart/CartModal/StyledCartModal.styled.js
@@ -1,7 +1,8 @@
 import { styled } from "styled-components";
 
 export const StyledCartModal = styled.div`
-    position: absolute;
+    position: fixed;
+    z-index: 1000;
     top: 0;
     right: 0;
     width: 480px;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -70,14 +70,12 @@ function Header(props) {
               </NavLink>
             </li>
             <li>
-              <NavLink to="/cart">
                 <svg
                   onClick={props.openModal}
-                  style={{ width: "22.5px", height: "23.3px", fill: "#303030" }}
+                  style={{ cursor: 'pointer', width: "22.5px", height: "23.3px", fill: "#303030" }}
                 >
                   <use href={icons + "#basket"}></use>
                 </svg>
-              </NavLink>
             </li>
           </ul>
           <NavHeader />


### PR DESCRIPTION
Cart modal has now 'position: fixed;' and 'z-index;'
Header cart icon no more leads to the cart page: deleted navlink, set to modal opening.